### PR TITLE
feat: use italic formatting for transcription messages

### DIFF
--- a/docs/guides/voice-commands.md
+++ b/docs/guides/voice-commands.md
@@ -65,7 +65,7 @@ Anything else is sent directly to Claude:
 
 ```
 You: "list all python files"
-Bot: Heard: list all python files
+Bot: list all python files (italic)
 Bot: Here are the Python files...
 ```
 
@@ -73,10 +73,9 @@ Bot: Here are the Python files...
 
 ```
 You: "create a new file called test.py"
-Bot: Heard: create a new file called test.py
+Bot: create a new file called test.py (italic)
 Bot: Claude wants to: Write file: /code/test.py
-     Say 'approve' or 'reject'
-You: "approve"
+     [Approve] [Reject] buttons
 Bot: Approved.
 Bot: Created test.py with...
 ```
@@ -85,7 +84,7 @@ Bot: Created test.py with...
 
 ```
 You: "work on whisper"
-Bot: Heard: work on whisper
+Bot: work on whisper (italic)
 Bot: Switched to whisper (/code/whisper-server)
 
 You: "show the main file"

--- a/src/voice_agent/bot.py
+++ b/src/voice_agent/bot.py
@@ -169,7 +169,8 @@ class VoiceAgentBot:
         # Transcribe
         try:
             text = await transcribe(bytes(audio_bytes), self.settings.whisper_url)
-            await update.message.reply_text(f"Heard: {text}")
+            from html import escape
+            await update.message.reply_text(f"<i>{escape(text)}</i>", parse_mode="HTML")
         except TranscriptionError as e:
             logger.error("Transcription failed: %s", e)
             await update.message.reply_text(f"Transcription failed: {e}")

--- a/tests/e2e/test_voice_flow.py
+++ b/tests/e2e/test_voice_flow.py
@@ -49,9 +49,9 @@ class TestVoiceFlow:
         # Handle voice message
         await e2e_bot.handle_voice(update, context)
 
-        # Verify transcription was shown
+        # Verify transcription was shown (italic formatted)
         calls = update.message.reply_text.call_args_list
-        assert any("Heard: status" in str(call) for call in calls)
+        assert any("<i>status</i>" in str(call) for call in calls)
 
     async def test_permission_approval_flow(
         self,


### PR DESCRIPTION
## Summary
- Remove "Heard:" prefix from transcription messages
- Display transcription in italic using Telegram HTML formatting
- Escape HTML special characters to prevent formatting issues

Closes #19