### PR TITLE
feat: improve permission approval/rejection feedback

### DIFF
--- a/src/voice_agent/bot.py
+++ b/src/voice_agent/bot.py
@@ -207,15 +207,13 @@ class VoiceAgentBot:
             await self._handle_prompt(chat_id, command.text, update)
 
     async def _handle_approve(self, chat_id: int, update: Update) -> None:
-        """Handle permission approval."""
+        """Handle permission approval (silent - no feedback needed)."""
         session = self.session_manager.get(chat_id)
         if not session:
             await update.message.reply_text("No active session.")  # type: ignore
             return
 
-        if session.permission_handler.approve():
-            await update.message.reply_text("Approved.")  # type: ignore
-        else:
+        if not session.permission_handler.approve():
             await update.message.reply_text("No pending permission to approve.")  # type: ignore
 
     async def _handle_reject(self, chat_id: int, update: Update) -> None:
@@ -225,8 +223,13 @@ class VoiceAgentBot:
             await update.message.reply_text("No active session.")  # type: ignore
             return
 
+        # Get description before denying
+        desc = session.permission_handler.get_pending_description()
         if session.permission_handler.deny("User rejected via voice"):
-            await update.message.reply_text("Rejected.")  # type: ignore
+            from html import escape
+            await update.message.reply_text(  # type: ignore
+                f"❌ <b>Rejected:</b> {escape(desc or 'unknown')}", parse_mode="HTML"
+            )
         else:
             await update.message.reply_text("No pending permission to reject.")  # type: ignore
 
@@ -251,12 +254,17 @@ class VoiceAgentBot:
 
         if query.data == "approve":
             if session.permission_handler.approve():
-                await query.edit_message_text("Approved.")
+                await query.delete_message()
             else:
                 await query.edit_message_text("No pending permission.")
         elif query.data == "reject":
+            # Get description before denying (deny clears pending)
+            desc = session.permission_handler.get_pending_description()
             if session.permission_handler.deny("User rejected via button"):
-                await query.edit_message_text("Rejected.")
+                from html import escape
+                await query.edit_message_text(
+                    f"❌ <b>Rejected:</b> {escape(desc or 'unknown')}", parse_mode="HTML"
+                )
             else:
                 await query.edit_message_text("No pending permission.")
 

--- a/tests/integration/test_bot_handlers.py
+++ b/tests/integration/test_bot_handlers.py
@@ -80,7 +80,7 @@ class TestVoiceAgentBot:
         assert "Working directory" in call_args
 
     async def test_handle_transcription_approve(self, bot: VoiceAgentBot) -> None:
-        """Test handling approval transcription."""
+        """Test handling approval transcription (silent - no feedback)."""
         # Create session with pending permission
         from voice_agent.sessions.permissions import PendingPermission
 
@@ -95,7 +95,8 @@ class TestVoiceAgentBot:
 
         await bot._handle_transcription(123, "yes", update)
 
-        update.message.reply_text.assert_called_once_with("Approved.")
+        # Silent approval - no message sent
+        update.message.reply_text.assert_not_called()
 
     async def test_handle_transcription_reject(self, bot: VoiceAgentBot) -> None:
         """Test handling rejection transcription."""
@@ -103,7 +104,7 @@ class TestVoiceAgentBot:
 
         session = bot.session_manager.get_or_create(123)
         session.permission_handler.pending = PendingPermission(
-            tool_name="Write", input_data={}
+            tool_name="Write", input_data={"file_path": "/tmp/test.txt"}
         )
 
         update = MagicMock()
@@ -112,7 +113,9 @@ class TestVoiceAgentBot:
 
         await bot._handle_transcription(123, "no", update)
 
-        update.message.reply_text.assert_called_once_with("Rejected.")
+        update.message.reply_text.assert_called_once_with(
+            "❌ <b>Rejected:</b> Write file: /tmp/test.txt", parse_mode="HTML"
+        )
 
     async def test_handle_transcription_new_session(self, bot: VoiceAgentBot) -> None:
         """Test handling new session request."""
@@ -194,7 +197,7 @@ class TestVoiceAgentBot:
         update.message.reply_text.assert_not_called()
 
     async def test_handle_text_approve(self, bot: VoiceAgentBot) -> None:
-        """Test text approval handling."""
+        """Test text approval handling (silent - no feedback)."""
         from voice_agent.sessions.permissions import PendingPermission
 
         session = bot.session_manager.get_or_create(123)
@@ -209,7 +212,8 @@ class TestVoiceAgentBot:
 
         await bot.handle_text(update, MagicMock())
 
-        update.message.reply_text.assert_called_once_with("Approved.")
+        # Silent approval - no message sent
+        update.message.reply_text.assert_not_called()
 
     async def test_handle_text_no_message(self, bot: VoiceAgentBot) -> None:
         """Test text handler with missing message."""


### PR DESCRIPTION
## Summary
- Silent approval: delete the prompt message instead of showing "Approved"
- Rejection includes context: "Rejected: Write file: /tmp/test.txt"

Closes #21