### PR TITLE
feat: add escape/cancel functionality to stop running tasks

### DIFF
--- a/src/voice_agent/router.py
+++ b/src/voice_agent/router.py
@@ -16,6 +16,7 @@ class CommandType(Enum):
     NEW_SESSION = auto()
     CONTINUE_SESSION = auto()
     SWITCH_PROJECT = auto()
+    CANCEL = auto()
     PROMPT = auto()
 
 
@@ -42,10 +43,17 @@ REJECT_KEYWORDS = frozenset(
     {"no", "reject", "rejected", "stop", "deny", "denied", "cancel", "nope"}
 )
 STATUS_KEYWORDS = frozenset({"status", "what's happening", "progress", "state"})
-NEW_SESSION_KEYWORDS = frozenset({"new session", "fresh session", "start over", "reset"})
-CONTINUE_SESSION_KEYWORDS = frozenset(
-    {"continue", "resume", "continue session", "resume session", "pick up where we left off"}
+NEW_SESSION_KEYWORDS = frozenset(
+    {"new session", "fresh session", "start over", "reset"}
 )
+CONTINUE_SESSION_KEYWORDS = frozenset({
+    "continue", "resume", "continue session", "resume session",
+    "pick up where we left off",
+})
+CANCEL_KEYWORDS = frozenset({
+    "escape", "abort", "interrupt", "stop task", "cancel task",
+    "stop it", "fermati", "basta",
+})
 
 
 def parse_command(text: str, projects: dict[str, str] | None = None) -> ParsedCommand:
@@ -82,6 +90,11 @@ def parse_command(text: str, projects: dict[str, str] | None = None) -> ParsedCo
     for keyword in CONTINUE_SESSION_KEYWORDS:
         if keyword in lower_text:
             return ParsedCommand(command_type=CommandType.CONTINUE_SESSION, text=text)
+
+    # Check for cancel/escape keywords
+    for keyword in CANCEL_KEYWORDS:
+        if keyword in lower_text:
+            return ParsedCommand(command_type=CommandType.CANCEL, text=text)
 
     # Check for project switch commands
     if projects:


### PR DESCRIPTION
## Summary
- Add CANCEL command type with keywords: escape, abort, interrupt, stop task, cancel task, stop it, fermati, basta
- Add task tracking with `_active_tasks` and `_cancel_flags` dictionaries
- Add `_handle_cancel` method to gracefully cancel running tasks
- Add inline "🛑 Stop" button during task execution
- Update `/start` help message with cancel command info

Closes #24

## Test plan
- [ ] Send a prompt that takes time to process
- [ ] Say "escape" or "stop task" to cancel via voice/text
- [ ] Click the "🛑 Stop" button to cancel via inline button
- [ ] Verify task is cancelled and "⏹️ Task cancelled" message appears