### PR TITLE
fix: load user config (CLAUDE.md, MCP servers) on session start

### DIFF
--- a/src/voice_agent/sessions/manager.py
+++ b/src/voice_agent/sessions/manager.py
@@ -305,6 +305,8 @@ class SessionManager:
                 cwd=session.cwd,
                 can_use_tool=permission_callback,
                 cli_path=cli_path,
+                # Load user, project, and local settings (CLAUDE.md, MCP servers, etc.)
+                setting_sources=["user", "project", "local"],
             )
             session.sdk_client = ClaudeSDKClient(options=options)
             await session.sdk_client.__aenter__()


### PR DESCRIPTION
## Summary

- Add `setting_sources` parameter to load user, project, and local settings
- Enables CLAUDE.md preferences and MCP servers to be loaded on session start

## Test plan

- [x] Unit tests pass
- [x] Manual test: MCP servers available after restart

Closes #37