### PR TITLE
feat: session improvements - delete voice msgs, rename sessions

### DIFF
--- a/src/voice_agent/sessions/manager.py
+++ b/src/voice_agent/sessions/manager.py
@@ -411,6 +411,38 @@ class SessionManager:
             counter += 1
         return f"session-{counter}"
 
+    def rename_session(self, chat_id: int, old_name: str, new_name: str) -> bool:
+        """Rename a session.
+
+        Args:
+            chat_id: Telegram chat ID.
+            old_name: Current session name.
+            new_name: New session name.
+
+        Returns:
+            True if renamed, False if not found or name already exists.
+        """
+        if chat_id not in self.sessions:
+            return False
+
+        if old_name not in self.sessions[chat_id]:
+            return False
+
+        if new_name in self.sessions[chat_id]:
+            return False
+
+        session = self.sessions[chat_id].pop(old_name)
+        session.name = new_name
+        self.sessions[chat_id][new_name] = session
+
+        if self.active_sessions.get(chat_id) == old_name:
+            self.active_sessions[chat_id] = new_name
+
+        if self.storage:
+            self.storage.rename_session(chat_id, old_name, new_name)
+
+        return True
+
     def set_cwd(self, chat_id: int, cwd: str) -> Session:
         """Set the working directory for the active session.
 

--- a/src/voice_agent/sessions/storage.py
+++ b/src/voice_agent/sessions/storage.py
@@ -262,6 +262,34 @@ class SessionStorage:
         self._save()
         return True
 
+    def rename_session(self, chat_id: int, old_name: str, new_name: str) -> bool:
+        """Rename a session.
+
+        Args:
+            chat_id: Telegram chat ID.
+            old_name: Current session name.
+            new_name: New session name.
+
+        Returns:
+            True if renamed, False if not found or name exists.
+        """
+        state = self._data.get(chat_id)
+        if not state or old_name not in state.sessions:
+            return False
+
+        if new_name in state.sessions:
+            return False
+
+        session = state.sessions.pop(old_name)
+        session.name = new_name
+        state.sessions[new_name] = session
+
+        if state.active_session == old_name:
+            state.active_session = new_name
+
+        self._save()
+        return True
+
     def delete_chat(self, chat_id: int) -> bool:
         """Delete all sessions for a chat.
 


### PR DESCRIPTION
## Summary

- Delete voice messages after transcription to keep chat clean
- Add session rename functionality (✏️ button in /sessions dialog)

## Test plan

- [x] Voice messages are deleted after transcription
- [x] Rename button prompts for new name
- [x] Sessions can be renamed via text input