### PR TITLE
fix: use consistent python version in docker image

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -109,7 +109,7 @@
 
         # Docker image built with dockerTools (see nix/docker-image.nix)
         dockerImage = import ./nix/docker-image.nix {
-          inherit pkgs version imageTag claudeAgentSdk;
+          inherit pkgs version imageTag python claudeAgentSdk;
         };
 
         # =====================================================================

--- a/nix/docker-image.nix
+++ b/nix/docker-image.nix
@@ -2,15 +2,16 @@
   pkgs,
   version,
   imageTag,
+  python,
   claudeAgentSdk,
 }:
 let
-  pythonEnv = pkgs.python3.withPackages (
-    ps: with ps; [
-      python-telegram-bot
-      httpx
-      pydantic
-      pydantic-settings
+  pythonEnv = python.withPackages (
+    ps: [
+      ps.python-telegram-bot
+      ps.httpx
+      ps.pydantic
+      ps.pydantic-settings
       claudeAgentSdk
     ]
   );


### PR DESCRIPTION
Docker image was using pkgs.python3 (3.13) while claude_agent_sdk was built with python311 (3.11), causing ModuleNotFoundError at runtime.