### PR TITLE
feat: support image attachments in Telegram messages

### DIFF
--- a/src/voice_agent/sessions/__init__.py
+++ b/src/voice_agent/sessions/__init__.py
@@ -1,5 +1,6 @@
 """Session management for Claude Code SDK."""
 
+from voice_agent.sessions.image import ImageAttachment
 from voice_agent.sessions.manager import Session, SessionInfo, SessionManager
 from voice_agent.sessions.permissions import (
     PermissionHandler,
@@ -10,6 +11,7 @@ from voice_agent.sessions.storage import ChatStoredState, SessionStorage, Stored
 
 __all__ = [
     "ChatStoredState",
+    "ImageAttachment",
     "Session",
     "SessionInfo",
     "SessionManager",

--- a/src/voice_agent/sessions/image.py
+++ b/src/voice_agent/sessions/image.py
@@ -1,0 +1,16 @@
+"""Image attachment types for multimodal prompts."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ImageAttachment:
+    """An image attachment for sending to Claude.
+
+    Attributes:
+        data: Base64-encoded image data.
+        media_type: MIME type of the image (e.g. "image/jpeg").
+    """
+
+    data: str
+    media_type: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,40 @@ def mock_whisper_response() -> dict[str, Any]:
     return {"text": "list files in current directory"}
 
 
+@pytest.fixture
+def mock_telegram_photo_update() -> MagicMock:
+    """Create a mock Telegram Update with photo message."""
+    update = MagicMock()
+    update.effective_chat.id = 123
+
+    # Simulate photo sizes (Telegram sends multiple resolutions)
+    small_photo = MagicMock()
+    small_photo.file_id = "small-photo-id"
+    large_photo = MagicMock()
+    large_photo.file_id = "large-photo-id"
+    update.message.photo = [small_photo, large_photo]
+
+    update.message.caption = "What is in this image?"
+    update.message.document = None
+    update.message.reply_text = AsyncMock()
+    return update
+
+
+@pytest.fixture
+def mock_telegram_photo_context() -> MagicMock:
+    """Create a mock Telegram context for photo downloads."""
+    context = MagicMock()
+    context.bot.get_file = AsyncMock()
+
+    mock_file = MagicMock()
+    mock_file.download_as_bytearray = AsyncMock(
+        return_value=bytearray(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
+    )
+    context.bot.get_file.return_value = mock_file
+
+    return context
+
+
 class MockClaudeSession:
     """Mock Claude SDK session for testing."""
 


### PR DESCRIPTION
## Summary

- Add `handle_photo()` handler for photos and image documents sent via Telegram
- Add `ImageAttachment` dataclass and multimodal content block support in `send_prompt()`
- Uses Claude SDK's `AsyncIterable` query mode to pass base64-encoded images as content blocks
- Picks highest resolution photo, supports documents with image MIME types
- Default prompt when no caption: "Describe this image and assist with any requests"

## Test plan

- [x] `test_handle_photo_basic` - photo with caption
- [x] `test_handle_photo_no_caption` - photo without caption uses default prompt
- [x] `test_handle_photo_document` - image sent as document (e.g. PNG)
- [x] `test_handle_photo_not_allowed` - non-allowed chat rejected
- [x] `test_build_multimodal_message` - correct content block structure
- [x] `test_build_multimodal_message_multiple_images` - multiple images
- [x] `test_send_prompt_with_image` - end-to-end SDK query with image

Closes #40