### PR TITLE
fix: use absolute python path in docker entrypoint

### DIFF
--- a/nix/docker-image.nix
+++ b/nix/docker-image.nix
@@ -20,7 +20,7 @@ let
     set -euo pipefail
     export HOME=/tmp
     export PYTHONPATH="/app:''${PYTHONPATH:-}"
-    exec python -m voice_agent
+    exec ${pythonEnv}/bin/python -m voice_agent
   '';
 in
 pkgs.dockerTools.buildImage {


### PR DESCRIPTION
## Summary

- Use `${pythonEnv}/bin/python` instead of bare `python` in the docker start script
- Fixes container crash when `/nix:/nix` is mounted from host (which shadows image layer symlinks)
- The python env closure stays in the host nix store as a build dependency — no GC risk

## Test plan

- [x] `nix build .#docker-image` succeeds
- [x] Start script contains absolute `/nix/store/...-python3-env/bin/python` path
- [ ] Deploy to server with `just deploy`