### PR TITLE
fix: stop parsing voice transcriptions as commands

### DIFF
--- a/src/voice_agent/bot.py
+++ b/src/voice_agent/bot.py
@@ -211,8 +211,9 @@ class VoiceAgentBot:
             await update.message.reply_text(f"Transcription failed: {e}")
             return
 
-        # Route command
-        await self._handle_transcription(chat_id, text, update)
+        # Voice transcriptions are always sent as prompts to Claude.
+        # Commands come from typed text, /commands, and buttons only.
+        await self._handle_prompt(chat_id, text, update)
 
     async def handle_photo(
         self, update: Update, context: ContextTypes.DEFAULT_TYPE

--- a/tests/e2e/test_voice_flow.py
+++ b/tests/e2e/test_voice_flow.py
@@ -1,5 +1,6 @@
 """End-to-end tests for voice message flow."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -7,6 +8,26 @@ from pytest_httpx import HTTPXMock
 
 from voice_agent.bot import VoiceAgentBot
 from voice_agent.config import Settings
+
+
+def _make_voice_update(chat_id: int = 123) -> MagicMock:
+    """Create a mock Telegram Update for voice messages."""
+    update = MagicMock()
+    update.effective_chat.id = chat_id
+    update.message.voice.file_id = "test-file-id"
+    update.message.reply_text = AsyncMock()
+    update.message.delete = AsyncMock()
+    update.message.chat.send_message = AsyncMock()
+    return update
+
+
+def _make_voice_context(audio: bytes = b"audio") -> MagicMock:
+    """Create a mock Telegram context for voice downloads."""
+    context = MagicMock()
+    mock_file = MagicMock()
+    mock_file.download_as_bytearray = AsyncMock(return_value=bytearray(audio))
+    context.bot.get_file = AsyncMock(return_value=mock_file)
+    return context
 
 
 @pytest.fixture
@@ -26,113 +47,105 @@ class TestVoiceFlow:
         sample_audio_bytes: bytes,
     ) -> None:
         """Test complete flow from voice to transcription."""
-        # Mock whisper server
         httpx_mock.add_response(
             url="http://localhost:8080/transcribe",
-            json={"text": "status"},
+            json={"text": "list files in the current directory"},
         )
 
-        # Mock Telegram update
-        update = MagicMock()
-        update.effective_chat.id = 123
-        update.message.voice.file_id = "test-file-id"
-        update.message.reply_text = AsyncMock()
+        update = _make_voice_update()
+        context = _make_voice_context(sample_audio_bytes)
 
-        # Mock context with file download
-        context = MagicMock()
-        mock_file = MagicMock()
-        mock_file.download_as_bytearray = AsyncMock(
-            return_value=bytearray(sample_audio_bytes)
-        )
-        context.bot.get_file = AsyncMock(return_value=mock_file)
+        async def mock_send_prompt(*args, **kwargs):  # type: ignore
+            yield "Here are the files"
 
-        # Handle voice message
-        await e2e_bot.handle_voice(update, context)
+        with patch.object(e2e_bot.session_manager, "send_prompt", mock_send_prompt):
+            await e2e_bot.handle_voice(update, context)
+            await asyncio.sleep(0.05)
 
-        # Verify transcription was shown (italic formatted)
-        calls = update.message.reply_text.call_args_list
-        assert any("<i>status</i>" in str(call) for call in calls)
+        # Verify transcription echo was shown
+        calls = update.message.chat.send_message.call_args_list
+        assert any("list files" in str(call) for call in calls)
 
-    async def test_permission_approval_flow(
+    async def test_voice_does_not_parse_commands(
         self,
         e2e_bot: VoiceAgentBot,
         httpx_mock: HTTPXMock,
     ) -> None:
-        """Test permission request and approval flow."""
+        """Test that voice transcription is never parsed as a command.
+
+        Words like 'status', 'yes', 'cancel' should be sent to Claude
+        as prompts, not intercepted as bot commands.
+        """
+        for word in ("status", "yes", "cancel", "restart", "new session"):
+            httpx_mock.add_response(
+                url="http://localhost:8080/transcribe",
+                json={"text": word},
+            )
+
+            update = _make_voice_update()
+            context = _make_voice_context()
+
+            captured_prompt = None
+
+            async def mock_send_prompt(
+                chat_id: int, prompt: str, **kwargs: object
+            ) -> None:
+                nonlocal captured_prompt
+                captured_prompt = prompt
+                yield "ok"  # type: ignore[misc]
+
+            with patch.object(
+                e2e_bot.session_manager, "send_prompt", mock_send_prompt
+            ):
+                await e2e_bot.handle_voice(update, context)
+                await asyncio.sleep(0.05)
+
+            assert captured_prompt == word, (
+                f"Voice '{word}' should be sent as prompt, not parsed as command"
+            )
+
+    async def test_voice_approval_not_intercepted(
+        self,
+        e2e_bot: VoiceAgentBot,
+        httpx_mock: HTTPXMock,
+    ) -> None:
+        """Test that saying 'yes' via voice does NOT approve permissions."""
         from voice_agent.sessions.permissions import PendingPermission
 
-        # Create session with pending permission
         session = e2e_bot.session_manager.get_or_create(123)
         session.permission_handler.pending = PendingPermission(
             tool_name="Write",
             input_data={"file_path": "/tmp/test.txt"},
         )
 
-        # Mock first voice message (approval)
         httpx_mock.add_response(
             url="http://localhost:8080/transcribe",
             json={"text": "yes"},
         )
 
-        update = MagicMock()
-        update.effective_chat.id = 123
-        update.message.voice.file_id = "test-file-id"
-        update.message.reply_text = AsyncMock()
+        update = _make_voice_update()
+        context = _make_voice_context()
 
-        context = MagicMock()
-        mock_file = MagicMock()
-        mock_file.download_as_bytearray = AsyncMock(return_value=bytearray(b"audio"))
-        context.bot.get_file = AsyncMock(return_value=mock_file)
+        async def mock_send_prompt(*args, **kwargs):  # type: ignore
+            yield "ok"
 
-        await e2e_bot.handle_voice(update, context)
+        with patch.object(e2e_bot.session_manager, "send_prompt", mock_send_prompt):
+            await e2e_bot.handle_voice(update, context)
+            await asyncio.sleep(0.05)
 
-        # Verify approval was processed
-        calls = update.message.reply_text.call_args_list
-        assert any("Approved" in str(call) for call in calls)
-
-    async def test_session_switching_flow(
-        self,
-        e2e_bot: VoiceAgentBot,
-        httpx_mock: HTTPXMock,
-    ) -> None:
-        """Test project switching via voice."""
-        httpx_mock.add_response(
-            url="http://localhost:8080/transcribe",
-            json={"text": "switch to whisper"},
-        )
-
-        update = MagicMock()
-        update.effective_chat.id = 123
-        update.message.voice.file_id = "test-file-id"
-        update.message.reply_text = AsyncMock()
-
-        context = MagicMock()
-        mock_file = MagicMock()
-        mock_file.download_as_bytearray = AsyncMock(return_value=bytearray(b"audio"))
-        context.bot.get_file = AsyncMock(return_value=mock_file)
-
-        await e2e_bot.handle_voice(update, context)
-
-        # Verify project was switched
-        session = e2e_bot.session_manager.get(123)
-        assert session is not None
-        assert session.cwd == "/code/whisper-server"
+        # Permission should still be pending (not approved by voice)
+        assert session.permission_handler.pending is not None
 
     async def test_non_allowed_chat_ignored(
         self,
         e2e_bot: VoiceAgentBot,
     ) -> None:
         """Test that non-allowed chats are ignored."""
-        update = MagicMock()
-        update.effective_chat.id = 999  # Not in allowed list
-        update.message.voice.file_id = "test-file-id"
-        update.message.reply_text = AsyncMock()
-
+        update = _make_voice_update(chat_id=999)
         context = MagicMock()
 
         await e2e_bot.handle_voice(update, context)
 
-        # Should not attempt to download or reply
         context.bot.get_file.assert_not_called()
         update.message.reply_text.assert_not_called()
 
@@ -147,19 +160,11 @@ class TestVoiceFlow:
             status_code=500,
         )
 
-        update = MagicMock()
-        update.effective_chat.id = 123
-        update.message.voice.file_id = "test-file-id"
-        update.message.reply_text = AsyncMock()
-
-        context = MagicMock()
-        mock_file = MagicMock()
-        mock_file.download_as_bytearray = AsyncMock(return_value=bytearray(b"audio"))
-        context.bot.get_file = AsyncMock(return_value=mock_file)
+        update = _make_voice_update()
+        context = _make_voice_context()
 
         await e2e_bot.handle_voice(update, context)
 
-        # Verify error was reported
         calls = update.message.reply_text.call_args_list
         assert any("Transcription failed" in str(call) for call in calls)
 
@@ -168,16 +173,11 @@ class TestVoiceFlow:
         e2e_bot: VoiceAgentBot,
     ) -> None:
         """Test handling of file download errors."""
-        update = MagicMock()
-        update.effective_chat.id = 123
-        update.message.voice.file_id = "test-file-id"
-        update.message.reply_text = AsyncMock()
-
+        update = _make_voice_update()
         context = MagicMock()
         context.bot.get_file = AsyncMock(side_effect=Exception("Download failed"))
 
         await e2e_bot.handle_voice(update, context)
 
-        # Verify error was reported
         calls = update.message.reply_text.call_args_list
         assert any("Failed to download" in str(call) for call in calls)


### PR DESCRIPTION
Closes #77

Voice transcriptions were going through `parse_command()` which does keyword matching on words like "status", "yes", "cancel", "continue". This meant natural speech containing those words got intercepted as bot commands instead of being sent to Claude.

Now voice messages always go directly to `_handle_prompt()`. Command routing only applies to typed text messages, `/commands`, and inline buttons.