### PR TITLE
feat: optional NixOS module for systemd deployment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -280,6 +280,15 @@
 
         devShells.default = devShell;
 
+        # NixOS VM test: nix build .#checks.x86_64-linux.nixos-module
+        checks = pkgs.lib.optionalAttrs (system == "x86_64-linux") {
+          nixos-module = import ./nixos/test.nix {
+            inherit pkgs;
+            voiceAgentModule = import ./nixos/module.nix;
+            voiceAgentPackage = voiceAgent;
+          };
+        };
+
         apps = {
           default = {
             type = "app";

--- a/nixos/module.nix
+++ b/nixos/module.nix
@@ -125,15 +125,9 @@ in
           "anthropic-api-key:${cfg.anthropicApiKeyFile}"
         ];
 
-        # Hardening
+        # Hardening (light: service needs broad host access for
+        # ~/.claude/ sessions, /code/ workdirs, and process inspection)
         NoNewPrivileges = true;
-        ProtectSystem = "strict";
-        ProtectHome = "no"; # Needs ~/.claude/ access
-        ReadWritePaths = [
-          cfg.workingDirectory
-          "/home/${cfg.user}/.claude"
-          "/tmp"
-        ];
       };
 
       environment =

--- a/nixos/test.nix
+++ b/nixos/test.nix
@@ -1,0 +1,66 @@
+# NixOS VM test for the voice-agent module.
+#
+# Spins up a QEMU VM, imports the module, and verifies that:
+#   - The systemd service is created and enabled
+#   - Secret files are loaded via systemd credentials
+#   - The service starts and runs the voice-agent binary
+#
+# Run with: nix build .#checks.x86_64-linux.nixos-module
+{
+  pkgs,
+  voiceAgentModule,
+  voiceAgentPackage,
+}:
+pkgs.testers.nixosTest {
+  name = "voice-agent-module";
+
+  nodes.machine =
+    { ... }:
+    {
+      imports = [ voiceAgentModule ];
+
+      # Create dummy secret files for testing
+      systemd.tmpfiles.rules = [
+        "f /run/test-secrets/telegram-bot-token 0400 testuser users - fake-telegram-token"
+        "f /run/test-secrets/anthropic-api-key 0400 testuser users - fake-anthropic-key"
+      ];
+
+      users.users.testuser = {
+        isNormalUser = true;
+        home = "/home/testuser";
+      };
+
+      services.voice-agent = {
+        enable = true;
+        package = voiceAgentPackage;
+        user = "testuser";
+        telegramBotTokenFile = "/run/test-secrets/telegram-bot-token";
+        anthropicApiKeyFile = "/run/test-secrets/anthropic-api-key";
+        workingDirectory = "/tmp";
+        whisperUrl = "http://localhost:9003/transcribe";
+      };
+    };
+
+  testScript = ''
+    import time
+
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    # Verify the service unit exists and is enabled
+    machine.succeed("systemctl is-enabled voice-agent.service")
+
+    # Verify unit configuration before it runs
+    env = machine.succeed("systemctl show voice-agent.service --property=Environment")
+    assert "DEFAULT_CWD=/tmp" in env, f"DEFAULT_CWD not set: {env}"
+    assert "WHISPER_URL=http://localhost:9003/transcribe" in env, f"WHISPER_URL not set: {env}"
+
+    # The service started (proven by wait_for_unit succeeding above).
+    # It will eventually fail because the Telegram token is fake, but
+    # the successful start proves: unit config, credentials loading,
+    # and binary execution all work.
+    time.sleep(3)
+    journal = machine.succeed("journalctl -u voice-agent.service --no-pager")
+    assert "Started Voice Agent" in journal, f"Service never started: {journal}"
+  '';
+}


### PR DESCRIPTION
Closes #83

## Summary
- Add `nixos/module.nix` with parameterized options (`services.voice-agent.*`)
- Expose as `nixosModules.default` in `flake.nix`
- Secrets via file references (sops-nix/agenix compatible)
- Application stays pure Python — zero NixOS dependency

## Module options
- `enable`, `package`, `user`, `group`
- `telegramBotTokenFile`, `anthropicApiKeyFile` (file paths, not inline secrets)
- `workingDirectory`, `whisperUrl`, `permissionTimeout`
- `extraEnvironment` for additional env vars

## Test plan
- [x] `nix flake check --no-build` passes
- [ ] Deploy on NixOS and verify systemd service starts
- [ ] Verify secret loading from credential files