### PR TITLE
feat: resume Claude sessions after process restart

### DIFF
--- a/src/voice_agent/sessions/manager.py
+++ b/src/voice_agent/sessions/manager.py
@@ -505,6 +505,8 @@ class SessionManager:
                 cli_path=cli_path,
                 # Load user, project, and local settings (CLAUDE.md, MCP servers, etc.)
                 setting_sources=["user", "project", "local"],
+                # Resume prior conversation if we have a stored session ID
+                resume=session.claude_session_id,
             )
             session.sdk_client = ClaudeSDKClient(options=options)
             await session.sdk_client.__aenter__()
@@ -616,13 +618,22 @@ class SessionManager:
                     for block in msg.content:
                         if isinstance(block, TextBlock):
                             yield block.text
-                elif isinstance(msg, ResultMessage) and msg.total_cost_usd:
-                    logger.info(
-                        "Chat %s session %s cost: $%.4f",
-                        chat_id,
-                        session.name,
-                        msg.total_cost_usd,
-                    )
+                elif isinstance(msg, ResultMessage):
+                    if msg.session_id and msg.session_id != session.claude_session_id:
+                        session.claude_session_id = msg.session_id
+                        logger.info(
+                            "Chat %s session %s claude_session_id: %s",
+                            chat_id,
+                            session.name,
+                            msg.session_id,
+                        )
+                    if msg.total_cost_usd:
+                        logger.info(
+                            "Chat %s session %s cost: $%.4f",
+                            chat_id,
+                            session.name,
+                            msg.total_cost_usd,
+                        )
 
             # Persist updated session
             self._persist_session(session)


### PR DESCRIPTION
Closes #82

## Summary
- Pass `resume=session.claude_session_id` to `ClaudeAgentOptions` when creating SDK client, reconnecting to prior conversation
- Capture `session_id` from `ResultMessage` and persist it to storage
- Sessions now survive voice-agent service restarts without losing context

## How it works
1. On first prompt, Claude creates a new session — the SDK returns a `session_id` in the `ResultMessage`
2. We capture and persist that ID to `sessions.json`
3. On next `_get_or_create_client()` (e.g. after restart), we pass `resume=<stored-id>` so Claude picks up the prior conversation

## Test plan
- [x] Unit tests pass (181/181)
- [ ] Send messages to bot, restart service, verify conversation context is preserved