### PR TITLE
refactor: orthogonal restart and clear commands

### DIFF
--- a/src/voice_agent/bot.py
+++ b/src/voice_agent/bot.py
@@ -293,10 +293,8 @@ class VoiceAgentBot:
             await self._handle_clear_sticky(chat_id, update)
         elif command.command_type == CommandType.STATUS:
             await self._handle_status(chat_id, update)
-        elif command.command_type == CommandType.NEW_SESSION:
-            await self._handle_new_session(chat_id, update)
-        elif command.command_type == CommandType.CONTINUE_SESSION:
-            await self._handle_continue_session(chat_id, update)
+        elif command.command_type == CommandType.CLEAR:
+            await self._handle_clear(chat_id, update)
         elif command.command_type == CommandType.SWITCH_PROJECT:
             await self._handle_switch_project(chat_id, command.project, update)
         elif command.command_type == CommandType.CANCEL:
@@ -523,32 +521,15 @@ class VoiceAgentBot:
         else:
             await update.message.reply_text("No active session.")  # type: ignore
 
-    async def _handle_new_session(self, chat_id: int, update: Update) -> None:
-        """Handle new session request."""
-        self.session_manager.create_new(chat_id)
-        await update.message.reply_text("Started new session.")  # type: ignore
-
-    async def _handle_continue_session(self, chat_id: int, update: Update) -> None:
-        """Handle continue/resume session request."""
-        if self.session_manager.has_resumable_session(chat_id):
-            session = self.session_manager.get(chat_id)
-            await update.message.reply_text(  # type: ignore
-                f"Resuming session in {session.cwd}\n"  # type: ignore
-                f"Messages: {session.message_count}"  # type: ignore
-            )
+    async def _handle_clear(self, chat_id: int, update: Update) -> None:
+        """Handle clear context request — wipe claude_session_id."""
+        session = self.session_manager.get(chat_id)
+        if session and session.claude_session_id:
+            session.claude_session_id = None
+            self.session_manager._persist_session(session)
+            await update.message.reply_text("Context cleared. Next message starts fresh.")  # type: ignore
         else:
-            # No resumable session, check if there's stored session data
-            session = self.session_manager.get(chat_id)
-            if session:
-                await update.message.reply_text(  # type: ignore
-                    f"Session active in {session.cwd}. No Claude session to resume.\n"
-                    "Send a message to start interacting."
-                )
-            else:
-                await update.message.reply_text(  # type: ignore
-                    "No previous session to resume. Starting fresh."
-                )
-                self.session_manager.create_new(chat_id)
+            await update.message.reply_text("No context to clear.")  # type: ignore
 
     async def _handle_switch_project(
         self, chat_id: int, project: str | None, update: Update
@@ -615,20 +596,29 @@ class VoiceAgentBot:
             self._active_tasks.pop(chat_id, None)
             self._cancel_flags.pop(chat_id, None)
 
-        # Clear sticky approvals from existing session
+        # Preserve claude_session_id across restart
         session = self.session_manager.get(chat_id)
+        saved_session_id = session.claude_session_id if session else None
         sticky_count = 0
         if session:
             sticky_count = session.permission_handler.clear_sticky_approvals()
 
-        # Create fresh session (use async to properly close SDK client)
+        # Close SDK client and create fresh session
         await self.session_manager.create_new_async(chat_id)
+
+        # Restore claude_session_id so next message resumes context
+        if saved_session_id:
+            new_session = self.session_manager.get(chat_id)
+            if new_session:
+                new_session.claude_session_id = saved_session_id
+                self.session_manager._persist_session(new_session)
 
         # Build status message
         parts = ["🔄 Restarted."]
         if sticky_count > 0:
             parts.append(f"Cleared {sticky_count} auto-approval(s).")
-        parts.append("Fresh session started.")
+        if saved_session_id:
+            parts.append("Context preserved.")
         return " ".join(parts)
 
     async def _handle_sessions(self, chat_id: int, update: Update) -> None:

--- a/src/voice_agent/router.py
+++ b/src/voice_agent/router.py
@@ -16,8 +16,7 @@ class CommandType(Enum):
     CLEAR_STICKY = auto()
     LIST_APPROVALS = auto()
     STATUS = auto()
-    NEW_SESSION = auto()
-    CONTINUE_SESSION = auto()
+    CLEAR = auto()
     SWITCH_PROJECT = auto()
     CANCEL = auto()
     RESTART = auto()
@@ -48,16 +47,11 @@ REJECT_KEYWORDS = frozenset(
     {"no", "reject", "rejected", "stop", "deny", "denied", "cancel", "nope"}
 )
 STATUS_KEYWORDS = frozenset({"status", "what's happening", "progress", "state"})
-NEW_SESSION_KEYWORDS = frozenset(
-    {"new session", "fresh session", "start over", "reset"}
-)
-CONTINUE_SESSION_KEYWORDS = frozenset(
+CLEAR_KEYWORDS = frozenset(
     {
-        "continue",
-        "resume",
-        "continue session",
-        "resume session",
-        "pick up where we left off",
+        "clear",
+        "clear context",
+        "clear session",
     }
 )
 STICKY_APPROVE_KEYWORDS = frozenset(
@@ -140,15 +134,9 @@ def parse_command(text: str, projects: dict[str, str] | None = None) -> ParsedCo
         if keyword in lower_text:
             return ParsedCommand(command_type=CommandType.STATUS, text=text)
 
-    # Check for new session keywords
-    for keyword in NEW_SESSION_KEYWORDS:
-        if keyword in lower_text:
-            return ParsedCommand(command_type=CommandType.NEW_SESSION, text=text)
-
-    # Check for continue session keywords
-    for keyword in CONTINUE_SESSION_KEYWORDS:
-        if keyword in lower_text:
-            return ParsedCommand(command_type=CommandType.CONTINUE_SESSION, text=text)
+    # Check for clear context keywords (exact match)
+    if lower_text in CLEAR_KEYWORDS:
+        return ParsedCommand(command_type=CommandType.CLEAR, text=text)
 
     # Check for sticky approve keywords
     for keyword in STICKY_APPROVE_KEYWORDS:

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -40,28 +40,12 @@ class TestParseCommand:
 
     @pytest.mark.parametrize(
         "text",
-        ["new session", "New Session", "fresh session", "start over", "reset"],
+        ["clear", "Clear", "clear context", "clear session"],
     )
-    def test_new_session_keywords(self, text: str) -> None:
-        """Test new session keyword detection."""
+    def test_clear_keywords(self, text: str) -> None:
+        """Test clear context keyword detection."""
         result = parse_command(text)
-        assert result.command_type == CommandType.NEW_SESSION
-
-    @pytest.mark.parametrize(
-        "text",
-        [
-            "continue",
-            "Continue",
-            "resume",
-            "Resume",
-            "continue session",
-            "resume session",
-        ],
-    )
-    def test_continue_session_keywords(self, text: str) -> None:
-        """Test continue session keyword detection."""
-        result = parse_command(text)
-        assert result.command_type == CommandType.CONTINUE_SESSION
+        assert result.command_type == CommandType.CLEAR
 
     def test_switch_project_work_on(self) -> None:
         """Test 'work on PROJECT' format."""


### PR DESCRIPTION
## Summary
- `/restart` preserves Claude context (keeps claude_session_id) while resetting the SDK client and sticky approvals
- `/clear` wipes Claude context (sets claude_session_id to None) without restarting
- Removes old NEW_SESSION/CONTINUE_SESSION commands in favor of orthogonal restart/clear

Closes #82