### PR TITLE
fix: recreate SDK client per prompt to prevent stale responses

### DIFF
--- a/src/voice_agent/bot.py
+++ b/src/voice_agent/bot.py
@@ -1066,12 +1066,14 @@ class VoiceAgentBot:
 
                 response_buffer: list[str] = []
                 try:
+                    cancelled_by_flag = False
                     async for chunk in self.session_manager.send_prompt(
                         chat_id, text, images=images
                     ):
                         # Check if cancelled
                         if self._cancel_flags.get(chat_id, False):
                             logger.info("Task cancelled for chat %s", chat_id)
+                            cancelled_by_flag = True
                             break
                         response_buffer.append(chunk)
 
@@ -1082,8 +1084,16 @@ class VoiceAgentBot:
                             )
                             response_buffer = []
 
-                    # Send remaining
-                    if response_buffer and not self._cancel_flags.get(chat_id, False):
+                    if cancelled_by_flag:
+                        # Close SDK client to discard the interrupted
+                        # response stream — same as CancelledError path
+                        with contextlib.suppress(Exception):
+                            session = self.session_manager.get(chat_id)
+                            if session:
+                                await self.session_manager._close_client(
+                                    session
+                                )
+                    elif response_buffer:
                         await self._send_formatted(
                             update, "\n".join(response_buffer), chat_id
                         )

--- a/src/voice_agent/sessions/manager.py
+++ b/src/voice_agent/sessions/manager.py
@@ -601,6 +601,11 @@ class SessionManager:
         session.message_count += 1
 
         try:
+            # Always create a fresh SDK client for each prompt to avoid
+            # stale messages in the anyio memory stream from a previous
+            # response leaking into the next receive_response() call.
+            # Conversation context is preserved via resume=session_id.
+            await self._close_client(session)
             client = await self._get_or_create_client(session)
 
             if images:


### PR DESCRIPTION
## Summary
- Close and recreate SDK client before each prompt to prevent stale buffered messages from leaking into the next response
- Fix cancel-flag path in bot.py to properly close client

## Test plan
- [ ] Send multiple voice messages in quick succession
- [ ] Cancel mid-response and send a new message — verify response matches new prompt

Closes #?